### PR TITLE
feat(uiSortableMultiselection): change the `handle` element detection

### DIFF
--- a/src/ui.sortable.multiselection.js
+++ b/src/ui.sortable.multiselection.js
@@ -19,13 +19,8 @@ angular.module('ui.sortable.multiselection', [])
 
             // Mimic jQuery UI Sortable's handle property when determining if an item is selected
             if (jquerySortableHandleOption) {
-              var validHandle = false;
-              
-              $parent.find(jquerySortableHandleOption).find('*').addBack().each(function () {
-                if (this === e.target) {
-                  validHandle = true;
-                }
-              });
+              var validHandle = angular.element(e.target).is(jquerySortableHandleOption) ||
+                !!$this.find(jquerySortableHandleOption).find(e.target).length;
 
               if (!validHandle) {
                 return;


### PR DESCRIPTION
The clicked element is:
* either the `handle`
* or a descendant of the `handle` inside the current `uiSortableSelectable` element