### PR TITLE
feat(uiSortableMultiselection): emit event when the selections change

### DIFF
--- a/src/ui.sortable.multiselection.js
+++ b/src/ui.sortable.multiselection.js
@@ -51,6 +51,8 @@ angular.module('ui.sortable.multiselection', [])
               $this.toggleClass(selectedItemClass);
             }
             parentScope.sortableMultiSelect.lastIndex = index;
+
+            $parent.trigger('ui-sortable-selectionschanged');
           });
         }
       };


### PR DESCRIPTION
The `ui-sortable-selectionschanged` will be emitted by the `uiSortableSelectable` directive, when an element is clicked, on the `[ui-sortable]` element.
```js
$('[ui-sortable]').on('ui-sortable-selectionschanged', function(){
  console.log(arguments);
});
```
This will not work, if you directly start dragging an element, since jquery-ui-sortable will cancel the bubbling of the click event.
So, make sure to also use the `stop` event to clear your variables.

Related to #13