### PR TITLE
Add multiSelectOnClick to sortable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,31 +15,59 @@ Provide multiple element sorting in [UI-Sortable](https://github.com/angular-ui/
 
 ## ui.item.sortableMultiSelect API documentation
 
+### Allow multi-selection on click
+For better touch device support, use the option 'multiSelectOnClick'. This will allow click/tap to select and deselect individual items instead of requiring a modifier key to be held down.
+
+Example usage:
+
+```javascript
+// set the sortable options
+$scope.sortableOptions = uiSortableMultiSelectionMethods.extendOptions({
+  'multiSelectOnClick': true,
+  start: function() {
+    // ...
+  },
+  stop: function() {
+    // ...
+  }
+});
+```
+
+```html
+<ul class="sortable-list" ui-sortable="sortableOptions" ng-model="items">
+  <li ng-repeat="item in items" class="sortable-item" ui-sortable-selectable>
+    <div class="sortable-item__inner">{item.name}</div>
+  </li>
+</ul>
+```
+
+
+
 The `ui` argument of the available callbacks gets enriched with some extra properties as specified below:
 
 
 ### selectedIndexes
-Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>  
+Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>
 Holds the original indexes of the items dragged.
 
 ### selectedModels
-Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)> /`undefined`  
+Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)> /`undefined`
 Holds the JavaScript objects that is used as the model of the dragged items, as specified by the ng-repeat of the [`source`](#source) ui-sortable element and the [`ui.item.sortableMultiSelect.selectedIndexes`](#selectedindexes) property.
 
 
 
 ### indexes
-Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>  
+Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>
 Holds the original indexes of the sibling items dragged.
 
 ### models
-Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)>  
+Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)>
 Holds the JavaScript objects that is used as the model of the siblings of the dragged item, as specified by the ng-repeat of the [`source`](#source) ui-sortable element and the [`ui.item.sortableMultiSelect.indexes`](#indexes) property.
 
 ### moved
-Type: [Object](http://api.jquery.com/Types/#Object) /`undefined`  
+Type: [Object](http://api.jquery.com/Types/#Object) /`undefined`
 Holds the models of the dragged sibling items only when a sorting happens between two connected ui-sortable elements.
 
 ### sourceElement
-Type: [jQuery](http://api.jquery.com/Types/#jQuery)  
+Type: [jQuery](http://api.jquery.com/Types/#jQuery)
 Holds the ui-sortable element that the dragged item originated from.

--- a/README.md
+++ b/README.md
@@ -41,33 +41,31 @@ $scope.sortableOptions = uiSortableMultiSelectionMethods.extendOptions({
 </ul>
 ```
 
-
-
 The `ui` argument of the available callbacks gets enriched with some extra properties as specified below:
 
 
 ### selectedIndexes
-Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>
+Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>  
 Holds the original indexes of the items dragged.
 
 ### selectedModels
-Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)> /`undefined`
+Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)> /`undefined`  
 Holds the JavaScript objects that is used as the model of the dragged items, as specified by the ng-repeat of the [`source`](#source) ui-sortable element and the [`ui.item.sortableMultiSelect.selectedIndexes`](#selectedindexes) property.
 
 
 
 ### indexes
-Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>
+Type: [Array](http://api.jquery.com/Types/#Array)<[Integer](http://api.jquery.com/Types/#Integer)>  
 Holds the original indexes of the sibling items dragged.
 
 ### models
-Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)>
+Type: [Array](http://api.jquery.com/Types/#Array)<[Object](http://api.jquery.com/Types/#Object)>  
 Holds the JavaScript objects that is used as the model of the siblings of the dragged item, as specified by the ng-repeat of the [`source`](#source) ui-sortable element and the [`ui.item.sortableMultiSelect.indexes`](#indexes) property.
 
 ### moved
-Type: [Object](http://api.jquery.com/Types/#Object) /`undefined`
+Type: [Object](http://api.jquery.com/Types/#Object) /`undefined`  
 Holds the models of the dragged sibling items only when a sorting happens between two connected ui-sortable elements.
 
 ### sourceElement
-Type: [jQuery](http://api.jquery.com/Types/#jQuery)
+Type: [jQuery](http://api.jquery.com/Types/#jQuery)  
 Holds the ui-sortable element that the dragged item originated from.

--- a/src/ui.sortable.multiselection.js
+++ b/src/ui.sortable.multiselection.js
@@ -9,7 +9,11 @@ angular.module('ui.sortable.multiselection', [])
             var $this = angular.element(this);
 
             var $parent = $this.parent();
+
+            var multiSelectOnClick = $parent.sortable('option', 'multiSelectOnClick') || false;
+
             var isDisabled = $parent.sortable('option', 'disabled');
+
             if (isDisabled){
               return;
             }
@@ -24,7 +28,7 @@ angular.module('ui.sortable.multiselection', [])
             // Mimic jQuery UI Sortable's handle property when determining if an item is selected
             if (jquerySortableHandleOption) {
               var validHandle = false;
-              
+
               $parent.find(jquerySortableHandleOption).find('*').addBack().each(function () {
                 if (this === e.target) {
                   validHandle = true;
@@ -41,7 +45,7 @@ angular.module('ui.sortable.multiselection', [])
             var lastIndex = sortableMultiSelectState.lastIndex;
             var index = $this.index();
 
-            if (e.ctrlKey || e.metaKey) {
+            if (e.ctrlKey || e.metaKey || multiSelectOnClick) {
               $this.toggleClass(selectedItemClass);
             } else if (e.shiftKey && lastIndex !== undefined && lastIndex >= 0) {
               if (index > lastIndex) {
@@ -268,12 +272,12 @@ angular.module('ui.sortable.multiselection', [])
             // so that we can locate its position
             // after we remove the co-dragged elements
             var draggedModel = ngModel[newPosition];
-            
+
             // get the models and remove them from the list
             // the code should run in reverse order,
             // so that the indexes will not break
             var models = extractGroupedModelsFromIndexes(ngModel, indexes.above, indexes.below);
-          
+
             // add the models to the list
             Array.prototype.splice.apply(
               ngModel,


### PR DESCRIPTION
This is a minor change which allows for better touch-device support. 

If the `'multiSelectOnClick': true` option is included in the sortable options, a click on a sortable item will select/deselect, without requiring a modifier key to be held down.