### PR TITLE
Fixes for table td width broken when dragging

### DIFF
--- a/src/ui.sortable.multiselection.js
+++ b/src/ui.sortable.multiselection.js
@@ -158,6 +158,11 @@ angular.module('ui.sortable.multiselection', [])
                 .removeClass(selectedItemClass);
           }
 
+          // Fixes element with when dragging
+          item.children().each(function () {
+            $(this).width($(this).width());
+          });
+
           var selectedElements = item.parent().children('.' + selectedItemClass);
           var selectedSiblings = item.siblings('.' + selectedItemClass);
 


### PR DESCRIPTION
When dragging a table row, the td width is lost.